### PR TITLE
Bug: Negation considered outside of sentence span

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,12 +13,6 @@ repos:
     hooks:
       - id: add-trailing-comma
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
-    hooks:
-      - id: pyupgrade
-        args: [--keep-runtime-typing]
-
   - repo: https://github.com/myint/docformatter
     rev: v1.3.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ The following shows a simple example of how you can quickly apply sentiment anal
 import spacy
 import asent
 
-# load spacy pipeline
-nlp = spacy.load("en_core_web_lg")
+# create spacy pipeline
+nlp = spacy.blank('en')
+nlp.add_pipe('sentencizer')
 
 # add the rule-based sentiment model
 nlp.add_pipe("asent_en_v1")

--- a/asent/about.py
+++ b/asent/about.py
@@ -1,5 +1,5 @@
 __title__ = "asent"
 
-__version__ = "0.4.3"  # the ONLY source of version ID
+__version__ = "0.5.4"  # the ONLY source of version ID
 __download_url__ = "https://github.com/kennethenevoldsen/asent"
 __documentation__ = "https://kennethenevoldsen.github.io/asent"

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1,6 +1,11 @@
 News and Changelog
 ==============================
 
+* 0.5.3 (26/05/22)
+
+  - Fixed bug where negation and intensifiers were considered outside of the sentences boundaries. Adressing `58 <https://github.com/KennethEnevoldsen/asent/issues/58>`__.
+  - Improvements to the documentation. Thanks to @tomaarsen for the pull request.
+
 * 0.4.2 (28/05/22)
 
   - Added new Danish Dictionary from `AFINN <https://github.com/fnielsen/afinn>`__

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -1,0 +1,26 @@
+"""Test specifically targeted an bugs."""
+
+import spacy
+
+import asent  # noqa
+
+
+def test_no_negations_and_intensifiers_out_of_sentence():
+    """Test that no negations are not found outside the sentence span.
+
+    https://github.com/KennethEnevoldsen/asent/issues/58
+    """
+
+    # create spacy pipeline
+    nlp = spacy.blank("en")
+    nlp.add_pipe("sentencizer")
+
+    nlp.add_pipe("asent_en_v1")
+
+    text = "Would you do that? I would not. Very stupid is what that is."
+    doc = nlp(text)
+    assert doc[10]._.is_negated is None
+
+    text = "Would you do that? I would not very. Stupid is what that is."
+    doc = nlp(text)
+    assert doc[10]._.valence == doc[10]._.polarity.polarity


### PR DESCRIPTION
Fixes #58. Negations and intensifiers are now no longer considered outside of the sentence span. 