### PR TITLE
Fix sentiment scaling issue with "but" conjunction

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,16 @@
+install:
+	pip install -e ".[da, all, docs, tests]"
+
+lint:
+	pre-commit run --all-files
+
+test:
+	pytest -v
+
+static-type-check:
+	pyright src/
+
+pr:
+	make lint
+	make static-type-check
+	make test

--- a/src/asent/getters.py
+++ b/src/asent/getters.py
@@ -468,16 +468,18 @@ def but_check(
     before_but_scalar: float = BEFORE_BUT_SCALAR,
     after_but_scalar: float = AFTER_BUT_SCALAR,
 ) -> list:
-    contains_but = False
+    but_idx: Optional[int] = None
     for token in span:
         if token._.is_contrastive_conj:
             but_idx = token.i
-            contains_but = True
-    if contains_but is not False:
-        for i, s in enumerate(sentiment[0:but_idx]):  # type: ignore
-            sentiment[i] = s * before_but_scalar
-        for i, s in enumerate(sentiment[but_idx:]):  # type: ignore
-            sentiment[i] = s * after_but_scalar
+            break  # only the first but is considered
+    if but_idx is None:
+        return sentiment
+
+    for i, s in enumerate(sentiment[0:but_idx]):
+        sentiment[i] = s * before_but_scalar
+    for i, s in enumerate(sentiment[but_idx:]):
+        sentiment[i + but_idx] = s * after_but_scalar
     return sentiment
 
 


### PR DESCRIPTION
This pull request fixes a bug in the sentiment scaling function that occurs when the conjunction "but" is present in the text. The bug causes incorrect scaling of sentiment values before and after the "but" conjunction. The fix ensures that the sentiment values are correctly scaled based on the position of the "but" conjunction. This improves the accuracy of sentiment analysis in texts containing contrasting statements.

The pull request also includes a makefile that provides convenient commands for installation, linting, testing, and static type checking. The makefile allows developers to easily set up the project environment and perform common development tasks.

fixes #169 